### PR TITLE
Feature/legend

### DIFF
--- a/include/ascii/ascii.h
+++ b/include/ascii/ascii.h
@@ -98,7 +98,15 @@ public:
     for (auto &label_trace_pair : series_) {
       width = std::max(width, (int)label_trace_pair.second.size());
     }
-    width += offset_;
+    
+    int legend_padding = 0;
+    for (auto &label_trace_pair : series_) {
+      legend_padding = std::max(legend_padding, (int)label_trace_pair.first.length());
+    }
+
+    auto offset = offset_ + legend_padding;
+
+    width += offset;
 
     if (std::isnan(height_)) {
       height_ = range;
@@ -122,37 +130,40 @@ public:
     for (double y = min2; y <= max2; y++) {
       auto label = FormatLabel(std::round(min_ + (y - min2) * range / rows));
       // vertical reverse
-      screen[rows - (y - min2)][0] =
+      screen[rows - (y - min2)][legend_padding] =
           Text(label, Style().fg(Foreground::From(Color::BLUE)));
-      screen[rows - (y - min2)][offset_ - 1] =
+      screen[rows - (y - min2)][offset - 1] =
           Text((y == 0) ? symbols_["center"] : symbols_["axis"],
                Style().fg(Foreground::From(Color::CYAN)));
     }
 
-    // 7. Content
+    // 7. Legend
+    // TODO:
+
+    // 8. Content
     unsigned j = 0;
     for (auto &label_trace_pair : series_) {
       auto& trace = label_trace_pair.second;
       auto style = styles_[j++ % styles_.size()];
       auto y0 = std::round(trace[0] * ratio) - min2;
       // vertical reverse
-      screen[rows - y0][offset_ - 1] = Text(symbols_["center"], style);
+      screen[rows - y0][offset - 1] = Text(symbols_["center"], style);
 
       for (size_t i = 0; i < trace.size() - 1; i++) {
         auto y0 = std::round(trace[i] * ratio) - min2;
         auto y1 = std::round(trace[i + 1] * ratio) - min2;
 
         if (y0 == y1) {
-          screen[rows - y0][i + offset_] = Text(symbols_["parellel"], style);
+          screen[rows - y0][i + offset] = Text(symbols_["parellel"], style);
         } else {
-          screen[rows - y1][i + offset_] =
+          screen[rows - y1][i + offset] =
               Text(y0 > y1 ? symbols_["down"] : symbols_["up"], style);
-          screen[rows - y0][i + offset_] =
+          screen[rows - y0][i + offset] =
               Text(y0 > y1 ? symbols_["ldown"] : symbols_["lup"], style);
           auto from = std::min(y0, y1);
           auto to = std::max(y0, y1);
           for (size_t y = from + 1; y < to; y++) {
-            screen[rows - y][i + offset_] = Text(symbols_["vertical"], style);
+            screen[rows - y][i + offset] = Text(symbols_["vertical"], style);
           }
         }
       }

--- a/include/ascii/ascii.h
+++ b/include/ascii/ascii.h
@@ -68,9 +68,15 @@ public:
     return *this;
   }
 
-  /// Set offset of label.
+  /// Set offset of label from axis.
   Asciichart &offset(size_t offset) {
     offset_ = offset;
+    return *this;
+  }
+
+  /// Set padding between legend and label
+  Asciichart &legendPadding(size_t padding) {
+    legendPadding_ = padding;
     return *this;
   }
 
@@ -99,18 +105,24 @@ public:
       width = std::max(width, (int)label_trace_pair.second.size());
     }
     
-    int legend_padding = 0;
+    // determine width and height of legend, add to offset.
+    int legend_cols = 0, legend_rows = 0;
     for (auto &label_trace_pair : series_) {
-      legend_padding = std::max(legend_padding, (int)label_trace_pair.first.length());
+      legend_rows++;
+      legend_cols = std::max(legend_cols, (int)label_trace_pair.first.length());
     }
 
-    auto offset = offset_ + legend_padding;
+    auto offset = offset_ + legend_cols;
 
     width += offset;
 
     if (std::isnan(height_)) {
       height_ = range;
     }
+
+    // extend the height of the plot if we need more rows to display the legend
+    // than what the range of the data requires.
+    height_ = std::max((double)legend_rows, height_);
 
     // calculate ratio using height and range
     auto ratio = height_ / range;
@@ -130,7 +142,7 @@ public:
     for (double y = min2; y <= max2; y++) {
       auto label = FormatLabel(std::round(min_ + (y - min2) * range / rows));
       // vertical reverse
-      screen[rows - (y - min2)][legend_padding] =
+      screen[rows - (y - min2)][legend_cols] =
           Text(label, Style().fg(Foreground::From(Color::BLUE)));
       screen[rows - (y - min2)][offset - 1] =
           Text((y == 0) ? symbols_["center"] : symbols_["axis"],
@@ -138,36 +150,45 @@ public:
     }
 
     // 7. Legend
-    // TODO:
+    {
+      unsigned j = 0;
+      for (auto &label_trace_pair : series_) {
+        auto style = styles_[j % styles_.size()];
+        PutString(screen, label_trace_pair.first, style, j++, 0);
+      }      
+    }
 
     // 8. Content
-    unsigned j = 0;
-    for (auto &label_trace_pair : series_) {
-      auto& trace = label_trace_pair.second;
-      auto style = styles_[j++ % styles_.size()];
-      auto y0 = std::round(trace[0] * ratio) - min2;
-      // vertical reverse
-      screen[rows - y0][offset - 1] = Text(symbols_["center"], style);
+    {
+      unsigned j = 0;
+      for (auto &label_trace_pair : series_) {
+        auto& trace = label_trace_pair.second;
+        auto style = styles_[j++ % styles_.size()];
+        auto y0 = std::round(trace[0] * ratio) - min2;
+        // vertical reverse
+        screen[rows - y0][offset - 1] = Text(symbols_["center"], style);
 
-      for (size_t i = 0; i < trace.size() - 1; i++) {
-        auto y0 = std::round(trace[i] * ratio) - min2;
-        auto y1 = std::round(trace[i + 1] * ratio) - min2;
+        for (size_t i = 0; i < trace.size() - 1; i++) {
+          auto y0 = std::round(trace[i] * ratio) - min2;
+          auto y1 = std::round(trace[i + 1] * ratio) - min2;
 
-        if (y0 == y1) {
-          screen[rows - y0][i + offset] = Text(symbols_["parellel"], style);
-        } else {
-          screen[rows - y1][i + offset] =
-              Text(y0 > y1 ? symbols_["down"] : symbols_["up"], style);
-          screen[rows - y0][i + offset] =
-              Text(y0 > y1 ? symbols_["ldown"] : symbols_["lup"], style);
-          auto from = std::min(y0, y1);
-          auto to = std::max(y0, y1);
-          for (size_t y = from + 1; y < to; y++) {
-            screen[rows - y][i + offset] = Text(symbols_["vertical"], style);
+          if (y0 == y1) {
+            screen[rows - y0][i + offset] = Text(symbols_["parellel"], style);
+          } else {
+            screen[rows - y1][i + offset] =
+                Text(y0 > y1 ? symbols_["down"] : symbols_["up"], style);
+            screen[rows - y0][i + offset] =
+                Text(y0 > y1 ? symbols_["ldown"] : symbols_["lup"], style);
+            auto from = std::min(y0, y1);
+            auto to = std::max(y0, y1);
+            for (size_t y = from + 1; y < to; y++) {
+              screen[rows - y][i + offset] = Text(symbols_["vertical"], style);
+            }
           }
         }
-      }
+      }  
     }
+    
     return Print(screen);
   }
 
@@ -180,6 +201,7 @@ private:
   double max_;
   double height_;
   double offset_;
+  size_t legendPadding_ = 10;
 
   void InitSeries(std::vector<double> &series) { series_["series 0"] = series; }
 
@@ -197,7 +219,12 @@ private:
 
   void InitStyles() {
     styles_ = {Style().fg(Foreground::From(Color::RED)),
-               Style().fg(Foreground::From(Color::CYAN))};
+               Style().fg(Foreground::From(Color::CYAN)),
+               Style().fg(Foreground::From(Color::PURPLE)),
+               Style().fg(Foreground::From(Color::YELLOW)),
+               Style().fg(Foreground::From(Color::WHITE)),
+               Style().fg(Foreground::From(Color::DARK_GREY)),
+    };
   }
 
   void InitSymbols() {
@@ -207,9 +234,25 @@ private:
                 {"lup", "╯"},   {"vertical", "│"}};
   }
 
+  /// Writes each character of a string into its respective cell in the
+  /// `screen` array, starting from the upper left, `row` and `col`.
+  void PutString(
+    std::vector<std::vector<Text>> &screen, 
+    const std::string& str, 
+    const Style& style, 
+    unsigned row, unsigned col) {
+    for (unsigned i = 0; i < str.length(); i++) {
+      if (str[i] == '\n') {
+        row += 1; 
+      } else {
+        screen[row][col + i] = Text(str.substr(i,1), style);        
+      }
+    }
+  }
+
   std::string FormatLabel(double x) {
     std::stringstream ss;
-    ss << std::setw(10) << std::setfill(' ') << std::setprecision(2);
+    ss << std::setw(legendPadding_) << std::setfill(' ') << std::setprecision(2);
     ss << x;
     return ss.str();
   }


### PR DESCRIPTION
Added feature allowing the user to label data series in their plots using a new constructor leveraging std::unordered_map. Series can be labelled in the following way:

```
	Asciichart chart({
		{"truth pos", truth_pos_data}, 
		{"estimated pos", filtered_pos_data}
	});
```

Which would produce a chart like with a legend like this:

![legend](https://user-images.githubusercontent.com/1676878/190442594-b557e116-7f32-4c4b-aad4-b72b8c97f474.png)
 
The user isn't required to provide text labels for each series. Instead they may pass raw std::vectors, which will be automatically labelled. As an example:

```
Asciichart chart(std::vector<std::vector<double>>{truth_pos_data, filtered_pos_data});
```

Which would produce a chart like the following. Where `series n` corresponds to index `n` in the outer vector.

![default](https://user-images.githubusercontent.com/1676878/190443337-771d0d03-ee6c-4b29-ab73-30b2b505005e.png)
