### PR TITLE
Meson Support

### DIFF
--- a/include/ascii/ascii.h
+++ b/include/ascii/ascii.h
@@ -216,9 +216,9 @@ private:
   std::unordered_map<std::string, std::vector<double>> series_;
   std::vector<Style> styles_;
 
+  double height_;
   double min_;
   double max_;
-  double height_;
   double offset_;
   size_t legend_padding_;
   size_t basic_width_of_label_;

--- a/include/ascii/text.h
+++ b/include/ascii/text.h
@@ -27,8 +27,8 @@ public:
   }
 
 private:
-  Style style_;
   std::string text_;
+  Style style_;
 };
 } // namespace ascii
 #endif // !INCLUDE_ASCII_TEXT_H_

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,21 @@
+# Project Declaration
+project('asciichart', 'cpp', default_options: [
+  'cpp_std=c++17',
+  'warning_level=3'
+], version: '3.20')
+
+incs = include_directories('include')
+
+# Dependency Declaration
+# Parent projects using this subproject will able to call
+# asciichart_proj = subproject('asciichart')
+# asciichart_dep = asciichart_proj.get_variable('asciichart_dep')
+asciichart_dep = declare_dependency(
+  include_directories: incs,
+)
+
+plotter = executable(
+  'Plotter',
+  ['src' / 'plotter' / 'plotter.cc'],
+  include_directories: incs
+)


### PR DESCRIPTION
Hi!

I'm an avid [meson](https://mesonbuild.com/) user and since I'm using your tool in one of my repositories, I decided to see if I could add first-party support for meson in your repo!

This PR aims to do two things:
* Introduce support for `meson` via a `meson.build` file. This file should be unused and useless for `cmake` users, but it should make the life of people who want to add asciichart as a [meson subproject](https://mesonbuild.com/Subprojects.html) much easier. Although `meson` does have support for cmake and we could [just call cmake from meson to include asciichart](https://mesonbuild.com/CMake-module.html), I think there's a certain convenience in just having out of the box support for `meson`.
* Eliminate `-Wreorder` issues. I was building with `-Wall` and realized there's a couple warnings `gcc` spits out at me so I decided iron those out.

## Maintenance Duties

The included `meson.build` file is quite short and I don't think there's much to maintain in it. One thing worth considering is that the `version` number will need to get updated in `meson.build`. `meson`, to my knowledge, sadly doesn't support reading version numbers from a `VERSION` file, so this needs to be manually updated whenever it is updated in the `CMakeLists` file.

I doubt there will be other big changes to support, but I'm willing to support meson in this repo. If this PR seems interesting to you, let me know!