### PR TITLE
Minor improvements to meson and examples

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,12 @@
+library_headers = files([
+  'ascii/ascii.h',
+  'ascii/color.h',
+  'ascii/constants.h',
+  'ascii/style.h',
+  'ascii/text.h',
+])
+
+install_headers(library_headers, subdir: 'ascii')
+
+# For building the library we use all headers:
+inc_dirs = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -1,28 +1,21 @@
-# Project Declaration
 project(
   'asciichart',
   'cpp',
   default_options: [
     'cpp_std=c++17',
-    'warning_level=3'
+    'warning_level=3',
+    'buildtype=debugoptimized',
   ],
   license: 'MIT',
   meson_version: '>=0.57.0',
   version: files('VERSION'),
 )
 
-incs = include_directories('include')
-
+subdir('include')
 # Dependency Declaration
 # Parent projects using this subproject will able to call
 # asciichart_proj = subproject('asciichart')
 # asciichart_dep = asciichart_proj.get_variable('asciichart_dep')
-asciichart_dep = declare_dependency(
-  include_directories: incs,
-)
+asciichart_dep = declare_dependency(include_directories: inc_dirs)
 
-plotter = executable(
-  'Plotter',
-  ['src' / 'plotter' / 'plotter.cc'],
-  include_directories: incs
-)
+subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,1 @@
+subdir('plotter')

--- a/src/plotter/line_chart_example.cc
+++ b/src/plotter/line_chart_example.cc
@@ -90,14 +90,27 @@ namespace {
         << asciichart.type(Asciichart::LINE).show_legend(true).height(6).Plot();
   }
 
+  void usage(const char* p) {
+    std::cout << "usage: " << p << " [1-6]\n";
+  }
 }
 
-int main() {
-  // example1();
-  // example2();
-  // example3();
-  example_legend();
-  // example_legend2();
-  // animation();
+int main(int argc, char* argv[])
+{
+  if (argc != 2) {
+    usage(argv[0]);
+    return 1;
+  }
+
+  switch (std::stol(argv[1])) {
+  case 1: example1(); break;
+  case 2: example2(); break;
+  case 3: example3(); break;
+  case 4: example_legend(); break;
+  case 5: example_legend2(); break;
+  case 6: animation(); break;
+  default: usage(argv[0]); return 1;
+  }
+
   return 0;
 }

--- a/src/plotter/line_chart_example.cc
+++ b/src/plotter/line_chart_example.cc
@@ -6,12 +6,91 @@
 
 #include "ascii/ascii.h"
 
-void example1();
-void example2();
-void example3();
-void example_legend();
-void example_legend2();
-void animation();
+namespace {
+
+  void example1() {
+    using namespace ascii;
+    std::vector<double> series;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(15 * std::cos(i * (kPI * 8) / 120));
+    }
+
+    Asciichart asciichart(std::vector<std::vector<double>>{series});
+    std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
+  }
+
+  void example2() {
+    using namespace ascii;
+    std::vector<double> series;
+    std::vector<double> series2;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(15 * std::cos(i * (kPI * 8) / 120));
+      series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
+    }
+    Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
+    std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
+  }
+
+  void example3() {
+    using namespace ascii;
+    std::vector<double> series;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(3400 * std::cos(i * (kPI * 8) / 120));
+    }
+
+    Asciichart asciichart(std::vector<std::vector<double>>{series});
+    std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
+  }
+
+  void animation() {
+    using namespace ascii;
+    std::vector<double> series;
+    std::vector<double> series2;
+    int height = 6;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(15 * std::cos(i * (kPI * 8) / 120));
+      series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
+      Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
+      if (i != 0) {
+        for (int j = 0; j <= height; j++) {
+          std::cout << "\033[A\033[2K"; // This is used for clear previous chart
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      }
+      std::cout << asciichart.type(Asciichart::LINE)
+                       .show_legend(true)
+                       .height(height)
+                       .Plot();
+    }
+  }
+
+  void example_legend() {
+    using namespace ascii;
+    std::vector<double> series;
+    std::vector<double> series2;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(15 * std::cos(i * (kPI * 8) / 120));
+      series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
+    }
+    Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
+    std::cout
+        << asciichart.type(Asciichart::LINE).show_legend(true).height(6).Plot();
+  }
+
+  void example_legend2() {
+    using namespace ascii;
+    std::vector<double> series;
+    std::vector<double> series2;
+    for (int i = 0; i < 100; i += 2) {
+      series.push_back(15 * std::cos(i * (kPI * 8) / 120));
+      series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
+    }
+    Asciichart asciichart({{"A", series}, {"B", series2}});
+    std::cout
+        << asciichart.type(Asciichart::LINE).show_legend(true).height(6).Plot();
+  }
+
+}
 
 int main() {
   // example1();
@@ -21,86 +100,4 @@ int main() {
   // example_legend2();
   // animation();
   return 0;
-}
-
-void example1() {
-  using namespace ascii;
-  std::vector<double> series;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(15 * std::cos(i * (kPI * 8) / 120));
-  }
-
-  Asciichart asciichart(std::vector<std::vector<double>>{series});
-  std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
-}
-
-void example2() {
-  using namespace ascii;
-  std::vector<double> series;
-  std::vector<double> series2;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(15 * std::cos(i * (kPI * 8) / 120));
-    series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
-  }
-  Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
-  std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
-}
-
-void example3() {
-  using namespace ascii;
-  std::vector<double> series;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(3400 * std::cos(i * (kPI * 8) / 120));
-  }
-
-  Asciichart asciichart(std::vector<std::vector<double>>{series});
-  std::cout << asciichart.type(Asciichart::LINE).height(6).Plot();
-}
-
-void animation() {
-  using namespace ascii;
-  std::vector<double> series;
-  std::vector<double> series2;
-  int height = 6;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(15 * std::cos(i * (kPI * 8) / 120));
-    series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
-    Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
-    if (i != 0) {
-      for (int j = 0; j <= height; j++) {
-        std::cout << "\033[A\033[2K"; // This is used for clear previous chart
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
-    std::cout << asciichart.type(Asciichart::LINE)
-                     .show_legend(true)
-                     .height(height)
-                     .Plot();
-  }
-}
-
-void example_legend() {
-  using namespace ascii;
-  std::vector<double> series;
-  std::vector<double> series2;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(15 * std::cos(i * (kPI * 8) / 120));
-    series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
-  }
-  Asciichart asciichart(std::vector<std::vector<double>>{series, series2});
-  std::cout
-      << asciichart.type(Asciichart::LINE).show_legend(true).height(6).Plot();
-}
-
-void example_legend2() {
-  using namespace ascii;
-  std::vector<double> series;
-  std::vector<double> series2;
-  for (int i = 0; i < 100; i += 2) {
-    series.push_back(15 * std::cos(i * (kPI * 8) / 120));
-    series2.push_back(15 * std::sin(i * ((kPI * 4) / 100)));
-  }
-  Asciichart asciichart({{"A", series}, {"B", series2}});
-  std::cout
-      << asciichart.type(Asciichart::LINE).show_legend(true).height(6).Plot();
 }

--- a/src/plotter/meson.build
+++ b/src/plotter/meson.build
@@ -1,0 +1,3 @@
+executable('Plotter', ['line_chart_example.cc'],
+  dependencies: asciichart_dep
+)


### PR DESCRIPTION
I could not compile the project with meson after the clone. As the existing meson does not work with out-of-tree builds:
`meson setup /tmp/build/asciichart && meson compile -C /tmp/build/asciichart`

Also the sample had to be compiled for every example.